### PR TITLE
added method for SearchConversation

### DIFF
--- a/conversation.go
+++ b/conversation.go
@@ -96,3 +96,57 @@ func (r *Robin) GetConversationMessages(id string) ([]MessageResponseData, error
 
 	return newBody.MessageData, nil
 }
+
+func (r *Robin) SearchConversation(id, text string) ([]MessageResponseData, error) {
+
+	/*
+		an empty text string returns all messages in the conversation
+	*/
+
+	if len(id) == 0 {
+		return []MessageResponseData{}, errors.New("id cannot be empty")
+	}
+
+	body, err := json.Marshal(map[string]string{
+		"text": text,
+	})
+
+	if err != nil {
+		return []MessageResponseData{}, err
+	}
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest("POST", fmt.Sprintf(`%s/chat/search/message/%s`, baseUrl, id), bytes.NewBuffer(body))
+
+	if err != nil {
+		return []MessageResponseData{}, err
+	}
+
+	req.Header.Set("x-api-key", r.Secret)
+
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return []MessageResponseData{}, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []MessageResponseData{}, err
+	}
+
+	var newBody MessageResponse
+
+	if err := json.Unmarshal(body, &newBody); err != nil {
+		return []MessageResponseData{}, err
+	}
+
+	if newBody.Error {
+		return []MessageResponseData{}, errors.New(newBody.Msg)
+	}
+
+	return newBody.MessageData, nil
+}

--- a/conversation_test.go
+++ b/conversation_test.go
@@ -35,3 +35,18 @@ func TestRobin_GetConversationMessages(t *testing.T) {
 
 	fmt.Println(messages)
 }
+
+func TestRobin_SearchConversation(t *testing.T) {
+	notify := Robin{
+		Secret: "NT-QuNtKolpzoWLahimkIjGAllEcJwGrymaVxQX",
+		Tls:    true,
+	}
+
+	messages, err := notify.SearchConversation("610041ac411c882b47d633db", "hi")
+
+	if err != nil {
+		t.Error(err)
+	}else {
+		fmt.Println(messages)
+	}
+}


### PR DESCRIPTION
Added the `SearchConversation(id, text string) ([]MessageResponseData{}, error)` method as an extension of the `Robin` struct.

sending an empty text returns all the entries In the conversation,
the method rejects id with length of 0